### PR TITLE
fix calculate

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,6 +10,8 @@ function validateSchema(schema, data) {
   return true;
 }
 
+// 1. discounted_unit_price 와 unit_price 비교하여 discounted_unit_price 가 더 작으면 할인가 적용
+// 2. discounted_unit_price = unit_price 일때 volume_sale = true 면 volume_sale_price 적용
 function sumProducts(products) {
   try {
     validateSchema(productsSchema, products);
@@ -17,18 +19,15 @@ function sumProducts(products) {
     const sum = products.reduce((sum, p) => {
       const { product, unit } = p;
       let rowSum = 0;
-      if(product.discounted_unit_price <= product.unit_price){
-        rowSum = product.discounted_unit_price * unit;
-      }else if(product.volume_sale && (unit > 1)){
-        rowSum = (product.volume_sale_price * (unit - 1) ) + product.unit_price;
-      }else{
-        rowSum = unit_price * unit ;
+      if (product.discounted_unit_price === product.unit_price){ 
+          if(product.volume_sale && (unit > 1)){
+              rowSum = (product.volume_sale_price * (unit - 1) ) + product.unit_price;
+          }else {
+              rowSum = product.unit_price * unit;
+          }
+      }else if (product.discounted_unit_price < product.unit_price){
+          rowSum = product.discounted_unit_price * unit;
       }
-      // const price = product.discounted_unit_price <= product.unit_price ? 
-      //               product.discounted_unit_price : product.unit_price;
-      // const rowSum = product.volume_sale && (unit > 1) ?
-      //                 (product.volume_sale_price * (unit - 1) ) + product.unit_price 
-      //                 : price * unit ;
       return sum + rowSum;
     }, 0);
 

--- a/index.test.js
+++ b/index.test.js
@@ -92,3 +92,48 @@ test("sumProducts check2", () => {
   });
   
 
+test("볼륨세일 상품의 첫번째 unit은 정가로 합해져야 한다.", () =>{
+
+  const products = [
+    {
+        "id": 217,
+        "product": {
+            "id": 28,
+            "name": "LED방등∙거실등 교체",
+            "difficulty": "TBD",
+            "min_hour": 0,
+            "max_hour": 0,
+            "unit_price": 35000,
+            "discounted_unit_price": 35000,
+            "volume_sale_price": 17500,
+            "volume_sale": true,
+            "parts_included": false,
+            "is_start_price": false,
+            "depth": 1,
+            "category": "분류1",
+            "note": null,
+            "parent": 2,
+            "product_traverse": [
+                {
+                    "id": 2,
+                    "name": "전등∙조명",
+                    "depth": 0,
+                    "parent": null
+                },
+                {
+                    "id": 28,
+                    "name": "LED방등∙거실등 교체",
+                    "depth": 1,
+                    "parent": 2
+                }
+            ],
+            "published_at": "2021-07-30T09:36:58.000Z",
+            "created_at": "2021-07-29T15:36:58.000Z",
+            "updated_at": "2021-07-29T15:36:58.000Z"
+        },
+        "unit": 4
+    }
+];
+expect(sumProducts(products)).toBe(35000 + (17500 * 3 ));
+
+});


### PR DESCRIPTION
- 기존 로직이 discounted_unit_price 와 unit_price 가 같을 때 아예 volume_sale 여부를 보지 않고
계산하고 넘어가기 때문에 로직을 수정하였습니다.

1. discounted_unit_price, unit_price 가 같은지 검사 
1-2. 같다면 할인가가 없는것으로 volume_sale 을 하는 상품인지 검사
1-3. 같지 않고 discounted_unit_price 가 더 적다면 할인가로 계산
2. volume_sale = true 이고 unit > 1 일 때  volume_sale_price * unit 계산 / uint=1 이라면 unit_price * unit 으로 계산

피드백 부탁드려요!
@hongsw 
